### PR TITLE
Feature: Cleaner samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ lerna-debug.log*
 .npm
 
 # Optional eslint cache
-.eslintcache
+.eslintcache**/dist/
+samples/**/package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,5 @@ lerna-debug.log*
 .npm
 
 # Optional eslint cache
-.eslintcache**/dist/
-samples/**/package-lock.json
+.eslintcache
+**/dist/

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "markdownlint": "^0.25.0",
+        "markdownlint": "^0.25.1",
         "markdownlint-cli": "^0.30.0"
       }
     },
@@ -157,9 +157,9 @@
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "node_modules/markdown-it": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.0.tgz",
-      "integrity": "sha512-T345UZZ6ejQWTjG6PSEHplzNy5m4kF6zvUpHVDv8Snl/pEU0OxIK0jGg8YLVNwJvT8E0YJC7/2UvssJDk/wQCQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -172,11 +172,11 @@
       }
     },
     "node_modules/markdownlint": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.0.tgz",
-      "integrity": "sha512-HtmitJLnzMyPbxy0tkEkzM6GP8it9tshI2XC+eUB+ZcdtWx5sokakQGEGOPVhra2CB/qRRuFEJ9Xl+X/BaB9QQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "dependencies": {
-        "markdown-it": "12.3.0"
+        "markdown-it": "12.3.2"
       },
       "engines": {
         "node": ">=12"
@@ -432,9 +432,9 @@
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "markdown-it": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.0.tgz",
-      "integrity": "sha512-T345UZZ6ejQWTjG6PSEHplzNy5m4kF6zvUpHVDv8Snl/pEU0OxIK0jGg8YLVNwJvT8E0YJC7/2UvssJDk/wQCQ==",
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
       "requires": {
         "argparse": "^2.0.1",
         "entities": "~2.1.0",
@@ -444,11 +444,11 @@
       }
     },
     "markdownlint": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.0.tgz",
-      "integrity": "sha512-HtmitJLnzMyPbxy0tkEkzM6GP8it9tshI2XC+eUB+ZcdtWx5sokakQGEGOPVhra2CB/qRRuFEJ9Xl+X/BaB9QQ==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "requires": {
-        "markdown-it": "12.3.0"
+        "markdown-it": "12.3.2"
       }
     },
     "markdownlint-cli": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "markdownlint": "^0.25.0",
+    "markdownlint": "^0.25.1",
     "markdownlint-cli": "^0.30.0"
   },
   "scripts": {
-    "lint":"npx markdownlint '**/*.md' --ignore node_modules -c .markdownlint.json"
+    "lint":"npx markdownlint '**/*.md' --ignore **/node_modules/** -c .markdownlint.json"
   }
 }

--- a/samples/crypto-prices/index.ts
+++ b/samples/crypto-prices/index.ts
@@ -1,10 +1,10 @@
 import { ReadableApp } from "@scramjet/types";
-import { PassThrough } from "stream";
 import fetch from "node-fetch";
 
-const getData = async (currency: string, baseCurrency: string) =>
-    fetch(`https://api.coinbase.com/v2/prices/${currency}-${baseCurrency}/spot`)
-        .then(res => res.json());
+async function defer(interval: number) {
+    await new Promise(res => setTimeout(res, interval));
+}
+
 /**
  * Requests external API every 3 seconds.
  * Writes crypto prices to output stream.
@@ -13,17 +13,15 @@ const getData = async (currency: string, baseCurrency: string) =>
  * @param currency currency (default: 'BTC')
  * @param baseCurrency currency (default: 'USD')
  */
-const app: ReadableApp<string> = function(_stream, currency = "BTC", baseCurrency = "USD") {
-    const outputStream = new PassThrough();
-
-    setInterval(() => {
-        getData(currency, baseCurrency)
-            .then(data => {
-                outputStream.write(JSON.stringify(data) + "\r\n");
-            })
-    }, 3000);
-
-    return outputStream;
+const app: ReadableApp<string> = function(_stream, currency = "BTC", baseCurrency = "USD", interval = 3000) {
+    return async function* () {
+        while (true) {
+            const ref = defer(interval);
+            const data = await fetch(`https://api.coinbase.com/v2/prices/${currency}-${baseCurrency}/spot`);
+            yield JSON.stringify(await data.json()) + "\r\n";
+            await ref;
+        }
+    };
 };
 
 export default app;

--- a/samples/crypto-prices/index.ts
+++ b/samples/crypto-prices/index.ts
@@ -12,16 +12,20 @@ async function defer(interval: number) {
  * @param _stream - dummy input stream
  * @param currency currency (default: 'BTC')
  * @param baseCurrency currency (default: 'USD')
+ * @param interval how often to check
  */
-const app: ReadableApp<string> = function(_stream, currency = "BTC", baseCurrency = "USD", interval = 3000) {
-    return async function* () {
-        while (true) {
-            const ref = defer(interval);
-            const data = await fetch(`https://api.coinbase.com/v2/prices/${currency}-${baseCurrency}/spot`);
-            yield JSON.stringify(await data.json()) + "\r\n";
-            await ref;
-        }
-    };
+const app: ReadableApp<string> = async function* (
+    _stream, 
+    currency = "BTC", 
+    baseCurrency = "USD", 
+    interval = 3000
+) {
+    while (true) {
+        const ref = defer(interval);
+        const data = await fetch(`https://api.coinbase.com/v2/prices/${currency}-${baseCurrency}/spot`);
+        yield JSON.stringify(await data.json()) + "\r\n";
+        await ref;
+    }
 };
 
 export default app;

--- a/samples/crypto-prices/package-lock.json
+++ b/samples/crypto-prices/package-lock.json
@@ -1,21 +1,20 @@
 {
-  "name": "@scramjet/slack-read",
-  "version": "0.0.1",
+  "name": "@scramjet/crypto-prices",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@scramjet/slack-read",
-      "version": "0.0.1",
+      "name": "@scramjet/crypto-prices",
+      "version": "0.13.1",
       "license": "ISC",
       "dependencies": {
-        "axios": "^0.24.0",
-        "ws": "^8.4.0"
+        "node-fetch": "^2.6.1",
+        "scramjet": "^4.35.20"
       },
       "devDependencies": {
-        "@scramjet/types": "^0.13.3",
+        "@scramjet/types": "^0.13.1",
         "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
         "typescript": "^4.3.4"
       }
     },
@@ -41,50 +40,40 @@
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-status-codes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
     },
     "node_modules/rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
       "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true,
       "engines": {
         "node": ">=8.6.0"
       }
@@ -93,7 +82,6 @@
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -117,15 +105,19 @@
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
       "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -135,24 +127,18 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   },
@@ -179,42 +165,34 @@
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
-    },
     "http-status-codes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
     "papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
     },
     "rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A=="
     },
     "scramjet": {
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "requires": {
         "papaparse": "^5.3.1",
         "rereadable-stream": "^1.4.12",
@@ -224,20 +202,32 @@
     "scramjet-core": {
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw=="
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
-    "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "requires": {}
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/samples/crypto-prices/package.json
+++ b/samples/crypto-prices/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "postbuild": "cp -r node_modules package.json dist/"
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
   },
   "author": "",
   "license": "ISC",

--- a/samples/crypto-prices/tsconfig.json
+++ b/samples/crypto-prices/tsconfig.json
@@ -4,5 +4,5 @@
   },
   "include": [
     "./index.ts"
-  ],
+  ]
 }

--- a/samples/discord-slack-connection/discord-read/README.md
+++ b/samples/discord-slack-connection/discord-read/README.md
@@ -37,9 +37,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/discord-slack-connection/discord-read/package-lock.json
+++ b/samples/discord-slack-connection/discord-read/package-lock.json
@@ -1,890 +1,898 @@
 {
-    "name": "@scramjet/discord-write",
-    "version": "0.0.1",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "@scramjet/discord-write",
-            "version": "0.0.1",
-            "license": "ISC",
-            "dependencies": {
-                "@discordjs/builders": "^0.11.0",
-                "@discordjs/rest": "^0.2.0-canary.0",
-                "discord-api-types": "^0.26.1",
-                "discord.js": "^13.5.1",
-                "scramjet": "^4.36.0"
-            },
-            "devDependencies": {
-                "@scramjet/types": "^0.13.3",
-                "@types/node": "^16.0.0",
-                "scramjet": "^4.36.0",
-                "ts-node": "^10.0.0",
-                "typescript": "^4.5.4"
-            }
-        },
-        "node_modules/@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@discordjs/builders": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-            "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
-            "dependencies": {
-                "@sindresorhus/is": "^4.2.0",
-                "discord-api-types": "^0.26.0",
-                "ts-mixer": "^6.0.0",
-                "tslib": "^2.3.1",
-                "zod": "^3.11.6"
-            },
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@discordjs/collection": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-            "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@discordjs/rest": {
-            "version": "0.2.0-canary.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.2.0-canary.0.tgz",
-            "integrity": "sha512-jOxz1aqTEzn9N0qaJcZbHz6FbA0oq+vjpXUKkQzgfMihO6gC+kLlpRnFqG25T/aPYbjaR1UM/lGhrGBB1dutqg==",
-            "dependencies": {
-                "@discordjs/collection": "^0.3.2",
-                "@sapphire/async-queue": "^1.1.9",
-                "@sapphire/snowflake": "^3.0.0",
-                "discord-api-types": "^0.25.2",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.5",
-                "tslib": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=16.0.0"
-            }
-        },
-        "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
-            "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==",
-            "engines": {
-                "node": ">=16.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@discordjs/rest/node_modules/discord-api-types": {
-            "version": "0.25.2",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.2.tgz",
-            "integrity": "sha512-O243LXxb5gLLxubu5zgoppYQuolapGVWPw3ll0acN0+O8TnPUE2kFp9Bt3sTRYodw8xFIknOVxjSeyWYBpVcEQ==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@sapphire/async-queue": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-            "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@sapphire/snowflake": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.0.1.tgz",
-            "integrity": "sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ==",
-            "engines": {
-                "node": ">=v14.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "node_modules/@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "dependencies": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "node_modules/@sindresorhus/is": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-            "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/is?sponsor=1"
-            }
-        },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "node_modules/@types/node": {
-            "version": "16.11.19",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-            "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
-        },
-        "node_modules/@types/node-fetch": {
-            "version": "2.5.12",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-            "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-            "dependencies": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            }
-        },
-        "node_modules/@types/node-fetch/node_modules/form-data": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-            "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/@types/ws": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-            "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
-            "dependencies": {
-                "@types/node": "*"
-            }
-        },
-        "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/discord-api-types": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-            "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/discord.js": {
-            "version": "13.5.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.1.tgz",
-            "integrity": "sha512-ejEG5MXzB0eda9Nt+VzqgdvDWVO5U/GynGzq6DRPLaCH1yyn2YRU9J+vCMl77pWA1rzYGX+b/9RI31x0wt3qXA==",
-            "dependencies": {
-                "@discordjs/builders": "^0.11.0",
-                "@discordjs/collection": "^0.4.0",
-                "@sapphire/async-queue": "^1.1.9",
-                "@types/node-fetch": "^2.5.12",
-                "@types/ws": "^8.2.2",
-                "discord-api-types": "^0.26.0",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.1",
-                "ws": "^8.4.0"
-            },
-            "engines": {
-                "node": ">=16.6.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "node_modules/mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-            "dependencies": {
-                "mime-db": "1.51.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            }
-        },
-        "node_modules/papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "node_modules/rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/scramjetorg"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
-                }
-            ],
-            "dependencies": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "node_modules/ts-mixer": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-            "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
-        },
-        "node_modules/ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "node_modules/ws": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-            "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.11.6",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-            "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
-            }
-        }
+  "name": "@scramjet/discord-write",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/discord-write",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "@discordjs/builders": "^0.11.0",
+        "@discordjs/rest": "^0.2.0-canary.0",
+        "discord-api-types": "^0.26.1",
+        "discord.js": "^13.5.1",
+        "scramjet": "^4.36.0"
+      },
+      "devDependencies": {
+        "@scramjet/types": "^0.13.3",
+        "@types/node": "^16.11.19",
+        "scramjet": "^4.36.0",
+        "ts-node": "^10.0.0",
+        "typescript": "^4.5.4"
+      }
     },
-    "dependencies": {
-        "@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
+      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "dependencies": {
+        "@sindresorhus/is": "^4.2.0",
+        "discord-api-types": "^0.26.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.1",
+        "zod": "^3.11.6"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
+      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "0.2.0-canary.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.2.0-canary.0.tgz",
+      "integrity": "sha512-jOxz1aqTEzn9N0qaJcZbHz6FbA0oq+vjpXUKkQzgfMihO6gC+kLlpRnFqG25T/aPYbjaR1UM/lGhrGBB1dutqg==",
+      "dependencies": {
+        "@discordjs/collection": "^0.3.2",
+        "@sapphire/async-queue": "^1.1.9",
+        "@sapphire/snowflake": "^3.0.0",
+        "discord-api-types": "^0.25.2",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.5",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
+      "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==",
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.2.tgz",
+      "integrity": "sha512-O243LXxb5gLLxubu5zgoppYQuolapGVWPw3ll0acN0+O8TnPUE2kFp9Bt3sTRYodw8xFIknOVxjSeyWYBpVcEQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
+      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.0.1.tgz",
+      "integrity": "sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "node_modules/@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "dependencies": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
+      "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@types/node-fetch/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
+      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/discord.js": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.1.tgz",
+      "integrity": "sha512-ejEG5MXzB0eda9Nt+VzqgdvDWVO5U/GynGzq6DRPLaCH1yyn2YRU9J+vCMl77pWA1rzYGX+b/9RI31x0wt3qXA==",
+      "dependencies": {
+        "@discordjs/builders": "^0.11.0",
+        "@discordjs/collection": "^0.4.0",
+        "@sapphire/async-queue": "^1.1.9",
+        "@types/node-fetch": "^2.5.12",
+        "@types/ws": "^8.2.2",
+        "discord-api-types": "^0.26.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "ws": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=16.6.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/mime-db": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "dependencies": {
+        "mime-db": "1.51.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "node_modules/rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scramjetorg"
         },
-        "@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            }
+        {
+          "type": "individual",
+          "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
+        }
+      ],
+      "dependencies": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+    },
+    "node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
         },
-        "@discordjs/builders": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
-            "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
-            "requires": {
-                "@sindresorhus/is": "^4.2.0",
-                "discord-api-types": "^0.26.0",
-                "ts-mixer": "^6.0.0",
-                "tslib": "^2.3.1",
-                "zod": "^3.11.6"
-            }
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
         },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
+      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  },
+  "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@discordjs/builders": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.11.0.tgz",
+      "integrity": "sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==",
+      "requires": {
+        "@sindresorhus/is": "^4.2.0",
+        "discord-api-types": "^0.26.0",
+        "ts-mixer": "^6.0.0",
+        "tslib": "^2.3.1",
+        "zod": "^3.11.6"
+      }
+    },
+    "@discordjs/collection": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
+      "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
+    },
+    "@discordjs/rest": {
+      "version": "0.2.0-canary.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.2.0-canary.0.tgz",
+      "integrity": "sha512-jOxz1aqTEzn9N0qaJcZbHz6FbA0oq+vjpXUKkQzgfMihO6gC+kLlpRnFqG25T/aPYbjaR1UM/lGhrGBB1dutqg==",
+      "requires": {
+        "@discordjs/collection": "^0.3.2",
+        "@sapphire/async-queue": "^1.1.9",
+        "@sapphire/snowflake": "^3.0.0",
+        "discord-api-types": "^0.25.2",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.5",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
         "@discordjs/collection": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.4.0.tgz",
-            "integrity": "sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw=="
-        },
-        "@discordjs/rest": {
-            "version": "0.2.0-canary.0",
-            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.2.0-canary.0.tgz",
-            "integrity": "sha512-jOxz1aqTEzn9N0qaJcZbHz6FbA0oq+vjpXUKkQzgfMihO6gC+kLlpRnFqG25T/aPYbjaR1UM/lGhrGBB1dutqg==",
-            "requires": {
-                "@discordjs/collection": "^0.3.2",
-                "@sapphire/async-queue": "^1.1.9",
-                "@sapphire/snowflake": "^3.0.0",
-                "discord-api-types": "^0.25.2",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.5",
-                "tslib": "^2.3.1"
-            },
-            "dependencies": {
-                "@discordjs/collection": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
-                    "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg=="
-                },
-                "discord-api-types": {
-                    "version": "0.25.2",
-                    "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.2.tgz",
-                    "integrity": "sha512-O243LXxb5gLLxubu5zgoppYQuolapGVWPw3ll0acN0+O8TnPUE2kFp9Bt3sTRYodw8xFIknOVxjSeyWYBpVcEQ=="
-                }
-            }
-        },
-        "@sapphire/async-queue": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-            "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
-        },
-        "@sapphire/snowflake": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.0.1.tgz",
-            "integrity": "sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ=="
-        },
-        "@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "requires": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "@sindresorhus/is": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
-            "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w=="
-        },
-        "@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "16.11.19",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
-            "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
-        },
-        "@types/node-fetch": {
-            "version": "2.5.12",
-            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
-            "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
-            "requires": {
-                "@types/node": "*",
-                "form-data": "^3.0.0"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
-                    "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.8",
-                        "mime-types": "^2.1.12"
-                    }
-                }
-            }
-        },
-        "@types/ws": {
-            "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
-            "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
-            "requires": {
-                "@types/node": "*"
-            }
-        },
-        "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true
-        },
-        "acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true
-        },
-        "arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
-        "combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
-        },
-        "create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
+          "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg=="
         },
         "discord-api-types": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
-            "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
-        },
-        "discord.js": {
-            "version": "13.5.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.1.tgz",
-            "integrity": "sha512-ejEG5MXzB0eda9Nt+VzqgdvDWVO5U/GynGzq6DRPLaCH1yyn2YRU9J+vCMl77pWA1rzYGX+b/9RI31x0wt3qXA==",
-            "requires": {
-                "@discordjs/builders": "^0.11.0",
-                "@discordjs/collection": "^0.4.0",
-                "@sapphire/async-queue": "^1.1.9",
-                "@types/node-fetch": "^2.5.12",
-                "@types/ws": "^8.2.2",
-                "discord-api-types": "^0.26.0",
-                "form-data": "^4.0.0",
-                "node-fetch": "^2.6.1",
-                "ws": "^8.4.0"
-            }
-        },
-        "form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            }
-        },
-        "http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "mime-db": {
-            "version": "1.51.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-            "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
-        },
-        "mime-types": {
-            "version": "2.1.34",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-            "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-            "requires": {
-                "mime-db": "1.51.0"
-            }
-        },
-        "node-fetch": {
-            "version": "2.6.6",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-            "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
-            "requires": {
-                "whatwg-url": "^5.0.0"
-            }
-        },
-        "papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true
-        },
-        "scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "requires": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            }
-        },
-        "scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true
-        },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "ts-mixer": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-            "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
-        },
-        "ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            }
-        },
-        "tslib": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true
-        },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
-        },
-        "ws": {
-            "version": "8.4.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-            "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-            "requires": {}
-        },
-        "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
-        },
-        "zod": {
-            "version": "3.11.6",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
-            "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
+          "version": "0.25.2",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.2.tgz",
+          "integrity": "sha512-O243LXxb5gLLxubu5zgoppYQuolapGVWPw3ll0acN0+O8TnPUE2kFp9Bt3sTRYodw8xFIknOVxjSeyWYBpVcEQ=="
         }
+      }
+    },
+    "@sapphire/async-queue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
+      "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+    },
+    "@sapphire/snowflake": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.0.1.tgz",
+      "integrity": "sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ=="
+    },
+    "@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "requires": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "@sindresorhus/is": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.1.tgz",
+      "integrity": "sha512-BrzrgtaqEre0qfvI8sMTaEvx+bayuhPmfe2rfeUGPPHYr/PLxCOqkOe4TQTDPb+qcqgNcsAtXV/Ew74mcDIE8w=="
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@types/ws": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "discord-api-types": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.26.1.tgz",
+      "integrity": "sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ=="
+    },
+    "discord.js": {
+      "version": "13.5.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.5.1.tgz",
+      "integrity": "sha512-ejEG5MXzB0eda9Nt+VzqgdvDWVO5U/GynGzq6DRPLaCH1yyn2YRU9J+vCMl77pWA1rzYGX+b/9RI31x0wt3qXA==",
+      "requires": {
+        "@discordjs/builders": "^0.11.0",
+        "@discordjs/collection": "^0.4.0",
+        "@sapphire/async-queue": "^1.1.9",
+        "@types/node-fetch": "^2.5.12",
+        "@types/ws": "^8.2.2",
+        "discord-api-types": "^0.26.0",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.1",
+        "ws": "^8.4.0"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+    },
+    "mime-types": {
+      "version": "2.1.34",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
+      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "requires": {
+        "mime-db": "1.51.0"
+      }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true
+    },
+    "scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "requires": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      }
+    },
+    "scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
+    "ts-mixer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
+      "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+    },
+    "ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      }
+    },
+    "tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "ws": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
+      "requires": {}
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    },
+    "zod": {
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.11.6.tgz",
+      "integrity": "sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg=="
     }
+  }
 }

--- a/samples/discord-slack-connection/discord-read/package.json
+++ b/samples/discord-slack-connection/discord-read/package.json
@@ -1,30 +1,31 @@
 {
-    "name": "@scramjet/discord-write",
-    "version": "0.0.1",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "build": "tsc -p tsconfig.json"
-    },
-    "author": "Scramjet <open-source@scramjet.org>",
-    "license": "ISC",
-    "type": "commonjs",
-    "devDependencies": {
-        "@scramjet/types": "^0.13.3",
-        "@types/node": "^16.11.19",
-        "scramjet": "^4.36.0",
-        "ts-node": "^10.0.0",
-        "typescript": "^4.5.4"
-    },
-    "dependencies": {
-        "@discordjs/builders": "^0.11.0",
-        "@discordjs/rest": "^0.2.0-canary.0",
-        "discord-api-types": "^0.26.1",
-        "discord.js": "^13.5.1",
-        "scramjet": "^4.36.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
-    }
+  "name": "@scramjet/discord-write",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@scramjet/types": "^0.13.3",
+    "@types/node": "^16.11.19",
+    "scramjet": "^4.36.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^4.5.4"
+  },
+  "dependencies": {
+    "@discordjs/builders": "^0.11.0",
+    "@discordjs/rest": "^0.2.0-canary.0",
+    "discord-api-types": "^0.26.1",
+    "discord.js": "^13.5.1",
+    "scramjet": "^4.36.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
+  }
 }

--- a/samples/discord-slack-connection/discord-read/tsconfig.json
+++ b/samples/discord-slack-connection/discord-read/tsconfig.json
@@ -7,10 +7,9 @@
         "module": "CommonJS",
         "outDir": "./dist",
         "esModuleInterop": true,
-        "resolveJsonModule": true,
-        // "skipLibCheck": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./index.ts"
-    ],
+    ]
 }

--- a/samples/discord-slack-connection/discord-write/README.md
+++ b/samples/discord-slack-connection/discord-write/README.md
@@ -19,9 +19,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/discord-slack-connection/discord-write/package-lock.json
+++ b/samples/discord-slack-connection/discord-write/package-lock.json
@@ -1,462 +1,462 @@
 {
-    "name": "@scramjet/discord-write",
-    "version": "0.0.1",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "@scramjet/discord-write",
-            "version": "0.0.1",
-            "license": "ISC",
-            "dependencies": {
-                "axios": "^0.24.0",
-                "scramjet": "^4.36.0"
-            },
-            "devDependencies": {
-                "@scramjet/types": "^0.13.3",
-                "@types/node": "15.12.5",
-                "scramjet": "^4.36.0",
-                "ts-node": "^10.0.0",
-                "typescript": "^4.3.4"
-            }
-        },
-        "node_modules/@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "node_modules/@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "dependencies": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "node_modules/@types/node": {
-            "version": "15.12.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-            "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-            "dev": true
-        },
-        "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.14.7",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "node_modules/papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "node_modules/rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/scramjetorg"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
-                }
-            ],
-            "dependencies": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        }
+  "name": "@scramjet/discord-write",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/discord-write",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^0.24.0",
+        "scramjet": "^4.36.0"
+      },
+      "devDependencies": {
+        "@scramjet/types": "^0.13.3",
+        "@types/node": "15.12.5",
+        "scramjet": "^4.36.0",
+        "ts-node": "^10.0.0",
+        "typescript": "^4.3.4"
+      }
     },
-    "dependencies": {
-        "@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true
-        },
-        "@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            }
-        },
-        "@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "requires": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "15.12.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-            "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-            "dev": true
-        },
-        "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true
-        },
-        "acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true
-        },
-        "arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "requires": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
-        "create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.14.7",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-            "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
-        },
-        "http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true
-        },
-        "scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "requires": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            }
-        },
-        "scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true
-        },
-        "ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            }
-        },
-        "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true
-        },
-        "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "node_modules/@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "dependencies": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
         }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "node_modules/rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scramjetorg"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
+        }
+      ],
+      "dependencies": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
+  },
+  "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "requires": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true
+    },
+    "scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "requires": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      }
+    },
+    "scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true
+    },
+    "ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
 }

--- a/samples/discord-slack-connection/discord-write/package.json
+++ b/samples/discord-slack-connection/discord-write/package.json
@@ -1,26 +1,27 @@
 {
-    "name": "@scramjet/discord-write",
-    "version": "0.0.1",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "build": "tsc -p tsconfig.json"
-    },
-    "author": "Scramjet <open-source@scramjet.org>",
-    "license": "ISC",
-    "devDependencies": {
-        "@scramjet/types": "^0.13.3",
-        "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
-        "ts-node": "^10.0.0",
-        "typescript": "^4.3.4"
-    },
-    "dependencies": {
-        "axios": "^0.24.0",
-        "scramjet": "^4.36.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
-    }
+  "name": "@scramjet/discord-write",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.13.3",
+    "@types/node": "15.12.5",
+    "scramjet": "^4.36.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.4"
+  },
+  "dependencies": {
+    "axios": "^0.24.0",
+    "scramjet": "^4.36.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
+  }
 }

--- a/samples/discord-slack-connection/discord-write/tsconfig.json
+++ b/samples/discord-slack-connection/discord-write/tsconfig.json
@@ -1,10 +1,15 @@
 {
     "compilerOptions": {
+        "lib": [
+            "ESNext"
+        ],
+        "target": "ESNext",
+        "module": "CommonJS",
         "outDir": "./dist",
         "esModuleInterop": true,
-        "resolveJsonModule": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./index.ts"
-    ],
+    ]
 }

--- a/samples/discord-slack-connection/slack-read/README.md
+++ b/samples/discord-slack-connection/slack-read/README.md
@@ -21,9 +21,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/discord-slack-connection/slack-read/package.json
+++ b/samples/discord-slack-connection/slack-read/package.json
@@ -1,31 +1,32 @@
 {
-    "name": "@scramjet/slack-read",
-    "version": "0.0.1",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "build": "tsc -p tsconfig.json"
-    },
-    "author": "Scramjet <open-source@scramjet.org>",
-    "license": "ISC",
-    "keywords": [
-        "slack",
-        "connection",
-        "sth",
-        "scramjet-transform-hub"
-      ],
-    "devDependencies": {
-        "@scramjet/types": "^0.13.3",
-        "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
-        "typescript": "^4.3.4"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
-    },
-    "dependencies": {
-        "axios": "^0.24.0",
-        "ws": "^8.4.0"
-    }
+  "name": "@scramjet/slack-read",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "keywords": [
+    "slack",
+    "connection",
+    "sth",
+    "scramjet-transform-hub"
+  ],
+  "devDependencies": {
+    "@scramjet/types": "^0.13.3",
+    "@types/node": "15.12.5",
+    "scramjet": "^4.36.0",
+    "typescript": "^4.3.4"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
+  },
+  "dependencies": {
+    "axios": "^0.24.0",
+    "ws": "^8.4.0"
+  }
 }

--- a/samples/discord-slack-connection/slack-read/tsconfig.json
+++ b/samples/discord-slack-connection/slack-read/tsconfig.json
@@ -1,10 +1,15 @@
 {
     "compilerOptions": {
+        "lib": [
+            "ESNext"
+        ],
+        "target": "ESNext",
+        "module": "CommonJS",
         "outDir": "./dist",
         "esModuleInterop": true,
-        "resolveJsonModule": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./index.ts"
-    ],
+    ]
 }

--- a/samples/discord-slack-connection/slack-write/README.md
+++ b/samples/discord-slack-connection/slack-write/README.md
@@ -20,9 +20,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/discord-slack-connection/slack-write/package-lock.json
+++ b/samples/discord-slack-connection/slack-write/package-lock.json
@@ -1,462 +1,462 @@
 {
-    "name": "@scramjet/slack-write",
-    "version": "0.0.1",
-    "lockfileVersion": 2,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "@scramjet/slack-write",
-            "version": "0.0.1",
-            "license": "ISC",
-            "dependencies": {
-                "axios": "^0.24.0",
-                "scramjet": "^4.36.0"
-            },
-            "devDependencies": {
-                "@scramjet/types": "^0.13.3",
-                "@types/node": "15.12.5",
-                "scramjet": "^4.36.0",
-                "ts-node": "^10.0.0",
-                "typescript": "^4.3.4"
-            }
-        },
-        "node_modules/@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 12"
-            }
-        },
-        "node_modules/@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "node_modules/@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "dependencies": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "node_modules/@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "node_modules/@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "node_modules/@types/node": {
-            "version": "15.12.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-            "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-            "dev": true
-        },
-        "node_modules/acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
-        "node_modules/create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "node_modules/diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.14.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-            "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "node_modules/make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "node_modules/papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "node_modules/rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/scramjetorg"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
-                }
-            ],
-            "dependencies": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true,
-            "engines": {
-                "node": ">=10.0.0"
-            }
-        },
-        "node_modules/ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "dependencies": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            },
-            "bin": {
-                "ts-node": "dist/bin.js",
-                "ts-node-cwd": "dist/bin-cwd.js",
-                "ts-node-script": "dist/bin-script.js",
-                "ts-node-transpile-only": "dist/bin-transpile.js",
-                "ts-script": "dist/bin-script-deprecated.js"
-            },
-            "peerDependencies": {
-                "@swc/core": ">=1.2.50",
-                "@swc/wasm": ">=1.2.50",
-                "@types/node": "*",
-                "typescript": ">=2.7"
-            },
-            "peerDependenciesMeta": {
-                "@swc/core": {
-                    "optional": true
-                },
-                "@swc/wasm": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=4.2.0"
-            }
-        },
-        "node_modules/yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
-            }
-        }
+  "name": "@scramjet/slack-write",
+  "version": "0.0.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/slack-write",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^0.24.0",
+        "scramjet": "^4.36.0"
+      },
+      "devDependencies": {
+        "@scramjet/types": "^0.13.3",
+        "@types/node": "15.12.5",
+        "scramjet": "^4.36.0",
+        "ts-node": "^10.0.0",
+        "typescript": "^4.3.4"
+      }
     },
-    "dependencies": {
-        "@cspotcode/source-map-consumer": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
-            "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
-            "dev": true
-        },
-        "@cspotcode/source-map-support": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
-            "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-consumer": "0.8.0"
-            }
-        },
-        "@scramjet/symbols": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
-            "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
-            "dev": true
-        },
-        "@scramjet/types": {
-            "version": "0.13.3",
-            "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
-            "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
-            "dev": true,
-            "requires": {
-                "@scramjet/symbols": "^0.13.3",
-                "http-status-codes": "^2.1.4"
-            }
-        },
-        "@tsconfig/node10": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
-            "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
-            "dev": true
-        },
-        "@tsconfig/node12": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
-            "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
-            "dev": true
-        },
-        "@tsconfig/node14": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
-            "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
-            "dev": true
-        },
-        "@tsconfig/node16": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
-            "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
-            "dev": true
-        },
-        "@types/node": {
-            "version": "15.12.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-            "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
-            "dev": true
-        },
-        "acorn": {
-            "version": "8.7.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-            "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-            "dev": true
-        },
-        "acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-            "dev": true
-        },
-        "arg": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-            "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
-        },
-        "axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "requires": {
-                "follow-redirects": "^1.14.4"
-            }
-        },
-        "create-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-            "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
-        },
-        "diff": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-            "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-            "dev": true
-        },
-        "follow-redirects": {
-            "version": "1.14.6",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-            "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
-        },
-        "http-status-codes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
-            "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
-            "dev": true
-        },
-        "make-error": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
-        },
-        "papaparse": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-            "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-            "dev": true
-        },
-        "rereadable-stream": {
-            "version": "1.4.13",
-            "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-            "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-            "dev": true
-        },
-        "scramjet": {
-            "version": "4.36.1",
-            "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
-            "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-            "dev": true,
-            "requires": {
-                "papaparse": "^5.3.1",
-                "rereadable-stream": "^1.4.12",
-                "scramjet-core": "^4.32.1"
-            }
-        },
-        "scramjet-core": {
-            "version": "4.32.2",
-            "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-            "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-            "dev": true
-        },
-        "ts-node": {
-            "version": "10.4.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-            "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
-            "dev": true,
-            "requires": {
-                "@cspotcode/source-map-support": "0.7.0",
-                "@tsconfig/node10": "^1.0.7",
-                "@tsconfig/node12": "^1.0.7",
-                "@tsconfig/node14": "^1.0.0",
-                "@tsconfig/node16": "^1.0.2",
-                "acorn": "^8.4.1",
-                "acorn-walk": "^8.1.1",
-                "arg": "^4.1.0",
-                "create-require": "^1.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "yn": "3.1.1"
-            }
-        },
-        "typescript": {
-            "version": "4.5.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-            "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
-            "dev": true
-        },
-        "yn": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-            "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-            "dev": true
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "node_modules/@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "dependencies": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
         }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "node_modules/papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "node_modules/rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scramjetorg"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
+        }
+      ],
+      "dependencies": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     }
+  },
+  "dependencies": {
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
+    "@scramjet/symbols": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
+      "dev": true
+    },
+    "@scramjet/types": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
+      "dev": true,
+      "requires": {
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
+      }
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
+    "papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
+      "dev": true
+    },
+    "rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "dev": true
+    },
+    "scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "dev": true,
+      "requires": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      }
+    },
+    "scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "dev": true
+    },
+    "ts-node": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
+      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "yn": "3.1.1"
+      }
+    },
+    "typescript": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "dev": true
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
+    }
+  }
 }

--- a/samples/discord-slack-connection/slack-write/package.json
+++ b/samples/discord-slack-connection/slack-write/package.json
@@ -1,26 +1,27 @@
 {
-    "name": "@scramjet/slack-write",
-    "version": "0.0.1",
-    "description": "",
-    "main": "index.js",
-    "scripts": {
-        "build": "tsc -p tsconfig.json"
-    },
-    "author": "Scramjet <open-source@scramjet.org>",
-    "license": "ISC",
-    "devDependencies": {
-        "@scramjet/types": "^0.13.3",
-        "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
-        "ts-node": "^10.0.0",
-        "typescript": "^4.3.4"
-    },
-    "dependencies": {
-        "axios": "^0.24.0",
-        "scramjet": "^4.36.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
-    }
+  "name": "@scramjet/slack-write",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
+  },
+  "author": "Scramjet <open-source@scramjet.org>",
+  "license": "ISC",
+  "devDependencies": {
+    "@scramjet/types": "^0.13.3",
+    "@types/node": "15.12.5",
+    "scramjet": "^4.36.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.4"
+  },
+  "dependencies": {
+    "axios": "^0.24.0",
+    "scramjet": "^4.36.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/scramjetorg/scramjet-cloud-docs.git"
+  }
 }

--- a/samples/discord-slack-connection/slack-write/tsconfig.json
+++ b/samples/discord-slack-connection/slack-write/tsconfig.json
@@ -1,10 +1,15 @@
 {
     "compilerOptions": {
+        "lib": [
+            "ESNext"
+        ],
+        "target": "ESNext",
+        "module": "CommonJS",
         "outDir": "./dist",
         "esModuleInterop": true,
-        "resolveJsonModule": true,
+        "resolveJsonModule": true
     },
     "include": [
         "./index.ts"
-    ],
+    ]
 }

--- a/samples/hello-snowman/package-lock.json
+++ b/samples/hello-snowman/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@scramjet/hello-snowman",
+  "version": "0.13.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/hello-snowman",
+      "version": "0.13.1",
+      "license": "GPL-3.0"
+    }
+  }
+}

--- a/samples/mediawiki/README.md
+++ b/samples/mediawiki/README.md
@@ -28,9 +28,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist/ -o mediawiki.tar.gz
 

--- a/samples/mediawiki/package-lock.json
+++ b/samples/mediawiki/package-lock.json
@@ -1,21 +1,21 @@
 {
-  "name": "@scramjet/slack-read",
-  "version": "0.0.1",
+  "name": "@scramjet/mediawiki",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@scramjet/slack-read",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "@scramjet/mediawiki",
+      "version": "0.13.1",
+      "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^0.24.0",
-        "ws": "^8.4.0"
+        "@types/eventsource": "^1.1.6",
+        "eventsource": "^1.1.0",
+        "scramjet": "^4.35.20"
       },
       "devDependencies": {
-        "@scramjet/types": "^0.13.3",
+        "@scramjet/types": "^0.13.1",
         "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
         "typescript": "^4.3.4"
       }
     },
@@ -35,37 +35,26 @@
         "http-status-codes": "^2.1.4"
       }
     },
+    "node_modules/@types/eventsource": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.8.tgz",
+      "integrity": "sha512-fJQNt9LijJCZwYvM6O30uLzdpAK9zs52Uc9iUW9M2Zsg0HQM6DLf6QysjC/wuFX+0798B8AppVMvgdO6IftPKQ=="
+    },
     "node_modules/@types/node": {
       "version": "15.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+    "node_modules/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
+        "original": "^1.0.0"
       },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/http-status-codes": {
@@ -74,17 +63,33 @@
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
       "dev": true
     },
+    "node_modules/original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dependencies": {
+        "url-parse": "^1.4.3"
+      }
+    },
     "node_modules/papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "node_modules/rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
       "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true,
       "engines": {
         "node": ">=8.6.0"
       }
@@ -93,7 +98,6 @@
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -117,15 +121,14 @@
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
       "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -135,24 +138,13 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+    "node_modules/url-parse": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
+      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     }
   },
@@ -173,24 +165,24 @@
         "http-status-codes": "^2.1.4"
       }
     },
+    "@types/eventsource": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.8.tgz",
+      "integrity": "sha512-fJQNt9LijJCZwYvM6O30uLzdpAK9zs52Uc9iUW9M2Zsg0HQM6DLf6QysjC/wuFX+0798B8AppVMvgdO6IftPKQ=="
+    },
     "@types/node": {
       "version": "15.12.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "original": "^1.0.0"
       }
-    },
-    "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "http-status-codes": {
       "version": "2.2.0",
@@ -198,23 +190,38 @@
       "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
       "dev": true
     },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
     "papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A=="
     },
     "scramjet": {
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "requires": {
         "papaparse": "^5.3.1",
         "rereadable-stream": "^1.4.12",
@@ -224,20 +231,22 @@
     "scramjet-core": {
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw=="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
     },
-    "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "requires": {}
+    "url-parse": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
+      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
     }
   }
 }

--- a/samples/mediawiki/package.json
+++ b/samples/mediawiki/package.json
@@ -4,7 +4,8 @@
   "description": "Sequence that keeps printing mediawiki event stream.",
   "main": "./index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
   },
   "author": "Scramjet <open-source@scramjet.org>",
   "license": "GPL-3.0",

--- a/samples/mediawiki/tsconfig.json
+++ b/samples/mediawiki/tsconfig.json
@@ -4,5 +4,5 @@
     },
     "include": [
       "./index.ts"
-    ],
+    ]
 }

--- a/samples/rss/README.md
+++ b/samples/rss/README.md
@@ -26,9 +26,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/rss/package.json
+++ b/samples/rss/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
   },
   "repository": {
     "type": "git",

--- a/samples/rss/tsconfig.json
+++ b/samples/rss/tsconfig.json
@@ -2,9 +2,9 @@
     "compilerOptions": {
       "outDir": "./dist",
       "esModuleInterop": true,
-      "resolveJsonModule": true,
+      "resolveJsonModule": true
     },
     "include": [
       "./index.ts"
-    ],
+    ]
 }

--- a/samples/simple-counter-js/package-lock.json
+++ b/samples/simple-counter-js/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "@scramjet/simple-counter-js",
+  "version": "0.13.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/simple-counter-js",
+      "version": "0.13.1",
+      "dependencies": {
+        "scramjet": "^4.35.20"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
+    },
+    "node_modules/rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/scramjetorg"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7F7V65C43EBMW"
+        }
+      ],
+      "dependencies": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "papaparse": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
+    },
+    "rereadable-stream": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A=="
+    },
+    "scramjet": {
+      "version": "4.36.1",
+      "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
+      "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
+      "requires": {
+        "papaparse": "^5.3.1",
+        "rereadable-stream": "^1.4.12",
+        "scramjet-core": "^4.32.1"
+      }
+    },
+    "scramjet-core": {
+      "version": "4.32.2",
+      "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw=="
+    }
+  }
+}

--- a/samples/stack-overflow/README.md
+++ b/samples/stack-overflow/README.md
@@ -30,9 +30,6 @@ npm install
 # transpile TS->JS to dist/
 npm run build
 
-# prepare standalone JS package
-cp -r node_modules package.json dist/
-
 # make a compressed package with sequence
 si pack dist
 

--- a/samples/stack-overflow/package-lock.json
+++ b/samples/stack-overflow/package-lock.json
@@ -1,54 +1,52 @@
 {
-  "name": "rss",
-  "version": "1.0.0",
+  "name": "@scramjet/stack-overflow",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rss",
-      "version": "1.0.0",
+      "name": "@scramjet/stack-overflow",
+      "version": "0.13.1",
       "license": "GPL-3.0",
       "dependencies": {
-        "@types/node": "^16.11.12",
-        "axios": "^0.24.0",
-        "cheerio": "^1.0.0-rc.10",
-        "rss-parser": "^3.12.0",
-        "scramjet": "^4.36.0",
-        "typescript": "^4.5.2"
+        "axios": "^0.21.4",
+        "cheerio": "*",
+        "scramjet": "^4.36.0"
       },
       "devDependencies": {
-        "@scramjet/types": "^0.11.0-0",
-        "@types/node": "^16.11.12",
-        "typescript": "^4.5.2"
+        "@scramjet/types": "^0.13.1",
+        "@types/node": "15.12.5",
+        "typescript": "^4.3.4"
       }
     },
     "node_modules/@scramjet/symbols": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.11.0.tgz",
-      "integrity": "sha512-UTuQVFy3IuG+un1B//k9dDoZEngsP0irJtTQamhzx5cd7AQzJUfGpwPVfgMhjcyEBKVrrGOUJIBFXO0cg8B0jw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
       "dev": true
     },
     "node_modules/@scramjet/types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.11.0.tgz",
-      "integrity": "sha512-Su84o3LxbsETCdm5I2LTYOaWjbsMM4XFPLzMSc4L2znAmnpZQf9D1q32frvPFb9vZRHHn9Cn3jkdyWAqC1eT0g==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
       "dev": true,
       "dependencies": {
-        "@scramjet/symbols": "^0.11.0"
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
       }
     },
     "node_modules/@types/node": {
-      "version": "16.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.13.tgz",
-      "integrity": "sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q==",
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
     "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "dependencies": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/boolbase": {
@@ -92,15 +90,15 @@
       }
     },
     "node_modules/css-select": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
-      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
+      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.0.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.6.0",
-        "nth-check": "^2.0.0"
+        "css-what": "^5.1.0",
+        "domhandler": "^4.3.0",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
@@ -213,6 +211,12 @@
         "entities": "^2.0.0"
       }
     },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
     "node_modules/nth-check": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
@@ -249,20 +253,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/rss-parser": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
-      "integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
-      "dependencies": {
-        "entities": "^2.0.3",
-        "xml2js": "^0.4.19"
-      }
-    },
-    "node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/scramjet": {
       "version": "4.36.1",
@@ -301,9 +291,9 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -312,56 +302,37 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "engines": {
-        "node": ">=4.0"
-      }
     }
   },
   "dependencies": {
     "@scramjet/symbols": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.11.0.tgz",
-      "integrity": "sha512-UTuQVFy3IuG+un1B//k9dDoZEngsP0irJtTQamhzx5cd7AQzJUfGpwPVfgMhjcyEBKVrrGOUJIBFXO0cg8B0jw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/symbols/-/symbols-0.13.3.tgz",
+      "integrity": "sha512-wWVbQKvsIln2w1Y6KZECzNOgtUeJMJsYooq0DFg2ZOJFIDNgUpQIwTr6DGZw5U2kA8N1l3AWUa0zcpd/Z8ul/g==",
       "dev": true
     },
     "@scramjet/types": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.11.0.tgz",
-      "integrity": "sha512-Su84o3LxbsETCdm5I2LTYOaWjbsMM4XFPLzMSc4L2znAmnpZQf9D1q32frvPFb9vZRHHn9Cn3jkdyWAqC1eT0g==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@scramjet/types/-/types-0.13.3.tgz",
+      "integrity": "sha512-P0sFtqhpUJKnha+sroZxuPcrZTVRa1PGzQ+OZJBqkts61+nP7B/IT0XrWynn/TdA6H+Kq0nW6H8IUsvUquDJOg==",
       "dev": true,
       "requires": {
-        "@scramjet/symbols": "^0.11.0"
+        "@scramjet/symbols": "^0.13.3",
+        "http-status-codes": "^2.1.4"
       }
     },
     "@types/node": {
-      "version": "16.11.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.13.tgz",
-      "integrity": "sha512-eUXZzHLHoZqj1frtUetNkUetYoJ6X55UmrVnFD4DMhVeAmwLjniZhtBmsRiemQh4uq4G3vUra/Ws/hs9vEvL3Q==",
+      "version": "15.12.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
+      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
     "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "requires": {
-        "follow-redirects": "^1.14.4"
+        "follow-redirects": "^1.14.0"
       }
     },
     "boolbase": {
@@ -396,15 +367,15 @@
       }
     },
     "css-select": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
-      "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
+      "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
       "requires": {
         "boolbase": "^1.0.0",
-        "css-what": "^5.0.0",
-        "domhandler": "^4.2.0",
-        "domutils": "^2.6.0",
-        "nth-check": "^2.0.0"
+        "css-what": "^5.1.0",
+        "domhandler": "^4.3.0",
+        "domutils": "^2.8.0",
+        "nth-check": "^2.0.1"
       }
     },
     "css-what": {
@@ -466,6 +437,12 @@
         "entities": "^2.0.0"
       }
     },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng==",
+      "dev": true
+    },
     "nth-check": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.0.1.tgz",
@@ -497,20 +474,6 @@
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
       "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A=="
     },
-    "rss-parser": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.12.0.tgz",
-      "integrity": "sha512-aqD3E8iavcCdkhVxNDIdg1nkBI17jgqF+9OqPS1orwNaOgySdpvq6B+DoONLhzjzwV8mWg37sb60e4bmLK117A==",
-      "requires": {
-        "entities": "^2.0.3",
-        "xml2js": "^0.4.19"
-      }
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "scramjet": {
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
@@ -532,24 +495,10 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      }
-    },
-    "xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     }
   }
 }

--- a/samples/stack-overflow/package.json
+++ b/samples/stack-overflow/package.json
@@ -4,7 +4,8 @@
   "description": "This a sequence that gets the number of changes in Stack Overflow tag count. This queries SO API every X minutes, gathers, compares and outputs result as difference.",
   "main": "index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
   },
   "author": "Scramjet <open-source@scramjet.org>",
   "license": "GPL-3.0",

--- a/samples/stack-overflow/tsconfig.json
+++ b/samples/stack-overflow/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "include": [
       "./index.ts"
-    ],
+    ]
   }

--- a/samples/test-output/package-lock.json
+++ b/samples/test-output/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@scramjet/test-output",
+  "version": "0.13.1",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@scramjet/test-output",
+      "version": "0.13.1",
+      "license": "GPL-3.0"
+    }
+  }
+}

--- a/samples/transform-string-stream/README.md
+++ b/samples/transform-string-stream/README.md
@@ -26,10 +26,7 @@ cd samples/transform-string-stream
 npm install 
 
 # transpile TS->JS to dist/
-npm run build 
-
-# prepare standalone JS package
-cp -r node_modules package.json dist/
+npm run build
 
 # make a compressed package with sequence
 si pack dist/ -o transform-string-stream.tar.gz

--- a/samples/transform-string-stream/package-lock.json
+++ b/samples/transform-string-stream/package-lock.json
@@ -1,22 +1,23 @@
 {
-  "name": "@scramjet/slack-read",
-  "version": "0.0.1",
+  "name": "@scramjet/transform-string-stream",
+  "version": "0.13.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@scramjet/slack-read",
-      "version": "0.0.1",
-      "license": "ISC",
+      "name": "@scramjet/transform-string-stream",
+      "version": "0.13.1",
+      "license": "GPL-3.0",
       "dependencies": {
-        "axios": "^0.24.0",
-        "ws": "^8.4.0"
+        "scramjet": "^4.35.20"
       },
       "devDependencies": {
-        "@scramjet/types": "^0.13.3",
+        "@scramjet/types": "^0.13.1",
         "@types/node": "15.12.5",
-        "scramjet": "^4.36.0",
         "typescript": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@scramjet/symbols": {
@@ -41,33 +42,6 @@
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/http-status-codes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
@@ -77,14 +51,12 @@
     "node_modules/papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
     },
     "node_modules/rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
       "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true,
       "engines": {
         "node": ">=8.6.0"
       }
@@ -93,7 +65,6 @@
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -117,15 +88,14 @@
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
       "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -133,26 +103,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     }
   },
@@ -179,19 +129,6 @@
       "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
       "dev": true
     },
-    "axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "requires": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
-    },
     "http-status-codes": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
@@ -201,20 +138,17 @@
     "papaparse": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.1.tgz",
-      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA==",
-      "dev": true
+      "integrity": "sha512-Dbt2yjLJrCwH2sRqKFFJaN5XgIASO9YOFeFP8rIBRG2Ain8mqk5r1M6DkfvqEVozVcz3r3HaUGw253hA1nLIcA=="
     },
     "rereadable-stream": {
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/rereadable-stream/-/rereadable-stream-1.4.13.tgz",
-      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A==",
-      "dev": true
+      "integrity": "sha512-g/HAYvVm1nXgmUAnqL01Zl3spGkZ9jqqlvIwlNd5O5FjQilq5BU6FeH65pcYP8Sn5lCenbpJ/+wGfkmQKKfp6A=="
     },
     "scramjet": {
       "version": "4.36.1",
       "resolved": "https://registry.npmjs.org/scramjet/-/scramjet-4.36.1.tgz",
       "integrity": "sha512-YUu47T/ZPBFOwxIWGbjQQR6NHtM1EOSueD4SQgQ5+A0U9ZYgd7skU65KSoSxAikuEj65SDWsoZ+mUiphe7Mv0A==",
-      "dev": true,
       "requires": {
         "papaparse": "^5.3.1",
         "rereadable-stream": "^1.4.12",
@@ -224,20 +158,13 @@
     "scramjet-core": {
       "version": "4.32.2",
       "resolved": "https://registry.npmjs.org/scramjet-core/-/scramjet-core-4.32.2.tgz",
-      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw==",
-      "dev": true
+      "integrity": "sha512-EST5NSFwKsiUc6yO0SUEImptI18SlQ/NeYW9hdaXWUi1KHb0+pWZak3XvuzefL7uNipB6zjPCQUZzz/SpBcgJw=="
     },
     "typescript": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
-      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
       "dev": true
-    },
-    "ws": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
-      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
-      "requires": {}
     }
   }
 }

--- a/samples/transform-string-stream/package.json
+++ b/samples/transform-string-stream/package.json
@@ -5,7 +5,8 @@
   "main": "index",
   "types": "dist/index",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "postbuild": "cp -r package.json dist/ && (cd dist && npm i --only=production)"
   },
   "engines": {
     "node": ">=10"
@@ -27,5 +28,7 @@
     "type": "git",
     "url": "https://github.com/scramjetorg/transform-hub.git"
   },
-  "assets": ["name.txt"]
+  "assets": [
+    "name.txt"
+  ]
 }

--- a/samples/transform-string-stream/tsconfig.json
+++ b/samples/transform-string-stream/tsconfig.json
@@ -3,6 +3,6 @@
     "outDir": "./dist"
   },
   "include": [
-    "./src",
-  ],
+    "./src"
+  ]
 }


### PR DESCRIPTION
I cleaned up the samples to:

* Replace the `stream..write` style samples with generator ones (adds backpressure)
* Add `postbuild` script that moves `package.json` to `dist` and installs production only deps
* Dependecies update
* Minor fixes to `README` to accomodate changes above.